### PR TITLE
Add KSL files and prefixed schema

### DIFF
--- a/schema.zed
+++ b/schema.zed
@@ -1,120 +1,120 @@
-definition rbac/workspace {
-	permission parent = t_parent
-	relation t_parent: rbac/workspace | rbac/tenant
-	permission notifications_daily_digest_preference_view = t_user_grant->notifications_daily_digest_preference_view + t_parent->notifications_daily_digest_preference_view
-	permission notifications_integration_subscribe_drawer = t_user_grant->notifications_integration_subscribe_drawer + t_parent->notifications_integration_subscribe_drawer
-	permission notifications_event_log_view = t_user_grant->notifications_event_log_view + t_parent->notifications_event_log_view
-	permission notifications_integration_view = t_user_grant->notifications_integration_view + t_parent->notifications_integration_view
-	permission notifications_daily_digest_preference_edit = t_user_grant->notifications_daily_digest_preference_edit + t_parent->notifications_daily_digest_preference_edit
-	permission notifications_integration_subscribe_email = t_user_grant->notifications_integration_subscribe_email + t_parent->notifications_integration_subscribe_email
-	permission notifications_integration_delete = t_user_grant->notifications_integration_delete + t_parent->notifications_integration_delete
-	permission user_grant = t_user_grant
-	relation t_user_grant: rbac/role_binding
-	permission notifications_integration_create = t_user_grant->notifications_integration_create + t_parent->notifications_integration_create
-	permission notifications_integration_edit = t_user_grant->notifications_integration_edit + t_parent->notifications_integration_edit
-	permission notifications_integration_disable = t_user_grant->notifications_integration_disable + t_parent->notifications_integration_disable
-	permission notifications_integration_enable = t_user_grant->notifications_integration_enable + t_parent->notifications_integration_enable
-	permission notifications_integration_test = t_user_grant->notifications_integration_test + t_parent->notifications_integration_test
-	permission notifications_integration_view_history = t_user_grant->notifications_integration_view_history + t_parent->notifications_integration_view_history
-}
-
-definition rbac/user {}
-
-definition rbac/realm {
-	permission notifications_daily_digest_preference_edit = t_user_grant->notifications_daily_digest_preference_edit
-	permission notifications_event_log_view = t_user_grant->notifications_event_log_view
-	permission notifications_integration_disable = t_user_grant->notifications_integration_disable
-	permission notifications_integration_enable = t_user_grant->notifications_integration_enable
-	permission notifications_integration_subscribe_drawer = t_user_grant->notifications_integration_subscribe_drawer
-	permission notifications_integration_subscribe_email = t_user_grant->notifications_integration_subscribe_email
-	permission notifications_integration_test = t_user_grant->notifications_integration_test
-	permission notifications_integration_view_history = t_user_grant->notifications_integration_view_history
-	permission user_grant = t_user_grant
-	relation t_user_grant: rbac/role_binding
-	permission notifications_integration_create = t_user_grant->notifications_integration_create
-	permission notifications_integration_edit = t_user_grant->notifications_integration_edit
-	permission notifications_integration_delete = t_user_grant->notifications_integration_delete
-	permission notifications_daily_digest_preference_view = t_user_grant->notifications_daily_digest_preference_view
-	permission notifications_integration_view = t_user_grant->notifications_integration_view
-}
-
-definition rbac/tenant {
-	permission member = t_member
-	relation t_member: rbac/user
-	permission notifications_daily_digest_preference_edit = t_user_grant->notifications_daily_digest_preference_edit + t_realm->notifications_daily_digest_preference_edit
-	permission notifications_daily_digest_preference_view = t_user_grant->notifications_daily_digest_preference_view + t_realm->notifications_daily_digest_preference_view
-	permission notifications_integration_subscribe_drawer = t_user_grant->notifications_integration_subscribe_drawer + t_realm->notifications_integration_subscribe_drawer
-	permission notifications_integration_subscribe_email = t_user_grant->notifications_integration_subscribe_email + t_realm->notifications_integration_subscribe_email
-	permission notifications_integration_view = t_user_grant->notifications_integration_view + t_realm->notifications_integration_view
-	permission notifications_integration_edit = t_user_grant->notifications_integration_edit + t_realm->notifications_integration_edit
-	permission user_grant = t_user_grant
-	relation t_user_grant: rbac/role_binding
-	permission notifications_integration_disable = t_user_grant->notifications_integration_disable + t_realm->notifications_integration_disable
-	permission notifications_integration_delete = t_user_grant->notifications_integration_delete + t_realm->notifications_integration_delete
-	permission notifications_integration_enable = t_user_grant->notifications_integration_enable + t_realm->notifications_integration_enable
-	permission notifications_integration_create = t_user_grant->notifications_integration_create + t_realm->notifications_integration_create
-	permission notifications_event_log_view = t_user_grant->notifications_event_log_view + t_realm->notifications_event_log_view
-	permission notifications_integration_test = t_user_grant->notifications_integration_test + t_realm->notifications_integration_test
-	permission notifications_integration_view_history = t_user_grant->notifications_integration_view_history + t_realm->notifications_integration_view_history
-	permission realm = t_realm
-	relation t_realm: rbac/realm
-}
-
-definition rbac/group {
-	permission member = t_member
-	relation t_member: rbac/user | rbac/group#member
-	permission owner = t_owner
-	relation t_owner: rbac/tenant
-}
-
-definition rbac/role {
-	permission notifications_integration_subscribe_email = notifications_integration_write
-	permission notifications_event_log_view = notifications_integration_read
-	permission notifications_integration_view = notifications_integration_read
-	permission notifications_integration_test = notifications_integration_write
-	permission notifications_integration_delete = notifications_integration_write
-	permission notifications_integration_enable = notifications_integration_write
-	permission notifications_daily_digest_preference_edit = notifications_integration_write
-	permission notifications_daily_digest_preference_view = notifications_integration_read
-	permission notifications_integration_edit = notifications_integration_write
-	permission notifications_integration_view_history = notifications_integration_read
-	permission notifications_integration_disable = notifications_integration_write
-	permission notifications_integration_write = t_notifications_integration_write
-	relation t_notifications_integration_write: rbac/user:*
-	permission notifications_integration_subscribe_drawer = notifications_integration_write
-	permission notifications_integration_read = t_notifications_integration_read
-	relation t_notifications_integration_read: rbac/user:*
-	permission notifications_integration_create = notifications_integration_read
-}
-
-definition rbac/role_binding {
-	permission granted = t_granted
-	relation t_granted: rbac/role
-	permission notifications_integration_create = (subject & t_granted->notifications_integration_create)
-	permission notifications_integration_subscribe_email = (subject & t_granted->notifications_integration_subscribe_email)
-	permission notifications_integration_view = (subject & t_granted->notifications_integration_view)
-	permission notifications_integration_delete = (subject & t_granted->notifications_integration_delete)
-	permission notifications_integration_disable = (subject & t_granted->notifications_integration_disable)
-	permission notifications_event_log_view = (subject & t_granted->notifications_event_log_view)
-	permission subject = t_subject
-	relation t_subject: rbac/user | rbac/group#member
-	permission notifications_daily_digest_preference_view = (subject & t_granted->notifications_daily_digest_preference_view)
-	permission notifications_integration_subscribe_drawer = (subject & t_granted->notifications_integration_subscribe_drawer)
-	permission notifications_integration_view_history = (subject & t_granted->notifications_integration_view_history)
-	permission notifications_daily_digest_preference_edit = (subject & t_granted->notifications_daily_digest_preference_edit)
-	permission notifications_integration_edit = (subject & t_granted->notifications_integration_edit)
-	permission notifications_integration_test = (subject & t_granted->notifications_integration_test)
-	permission notifications_integration_enable = (subject & t_granted->notifications_integration_enable)
-}
-
 definition notifications/integration {
+	permission enable = t_workspace->notifications_integration_enable
+	permission workspace = t_workspace
+	relation t_workspace: rbac/workspace
 	permission view = t_workspace->notifications_integration_view
 	permission edit = t_workspace->notifications_integration_edit
 	permission test = t_workspace->notifications_integration_test
 	permission view_history = t_workspace->notifications_integration_view_history
 	permission delete = t_workspace->notifications_integration_delete
 	permission disable = t_workspace->notifications_integration_disable
-	permission enable = t_workspace->notifications_integration_enable
-	permission workspace = t_workspace
-	relation t_workspace: rbac/workspace
 }
+
+definition rbac/realm {
+	permission notifications_integration_delete = t_user_grant->notifications_integration_delete
+	permission notifications_integration_create = t_user_grant->notifications_integration_create
+	permission notifications_daily_digest_preference_view = t_user_grant->notifications_daily_digest_preference_view
+	permission notifications_integration_subscribe_email = t_user_grant->notifications_integration_subscribe_email
+	permission notifications_integration_test = t_user_grant->notifications_integration_test
+	permission notifications_integration_view_history = t_user_grant->notifications_integration_view_history
+	permission user_grant = t_user_grant
+	relation t_user_grant: rbac/role_binding
+	permission notifications_daily_digest_preference_edit = t_user_grant->notifications_daily_digest_preference_edit
+	permission notifications_integration_edit = t_user_grant->notifications_integration_edit
+	permission notifications_integration_disable = t_user_grant->notifications_integration_disable
+	permission notifications_integration_enable = t_user_grant->notifications_integration_enable
+	permission notifications_integration_subscribe_drawer = t_user_grant->notifications_integration_subscribe_drawer
+	permission notifications_event_log_view = t_user_grant->notifications_event_log_view
+	permission notifications_integration_view = t_user_grant->notifications_integration_view
+}
+
+definition rbac/tenant {
+	permission notifications_daily_digest_preference_edit = t_user_grant->notifications_daily_digest_preference_edit + t_realm->notifications_daily_digest_preference_edit
+	permission notifications_integration_test = t_user_grant->notifications_integration_test + t_realm->notifications_integration_test
+	permission notifications_integration_enable = t_user_grant->notifications_integration_enable + t_realm->notifications_integration_enable
+	permission notifications_integration_subscribe_drawer = t_user_grant->notifications_integration_subscribe_drawer + t_realm->notifications_integration_subscribe_drawer
+	permission member = t_member
+	relation t_member: rbac/user
+	permission notifications_event_log_view = t_user_grant->notifications_event_log_view + t_realm->notifications_event_log_view
+	permission notifications_integration_view = t_user_grant->notifications_integration_view + t_realm->notifications_integration_view
+	permission notifications_integration_edit = t_user_grant->notifications_integration_edit + t_realm->notifications_integration_edit
+	permission notifications_integration_view_history = t_user_grant->notifications_integration_view_history + t_realm->notifications_integration_view_history
+	permission notifications_integration_subscribe_email = t_user_grant->notifications_integration_subscribe_email + t_realm->notifications_integration_subscribe_email
+	permission realm = t_realm
+	relation t_realm: rbac/realm
+	permission user_grant = t_user_grant
+	relation t_user_grant: rbac/role_binding
+	permission notifications_integration_delete = t_user_grant->notifications_integration_delete + t_realm->notifications_integration_delete
+	permission notifications_integration_disable = t_user_grant->notifications_integration_disable + t_realm->notifications_integration_disable
+	permission notifications_integration_create = t_user_grant->notifications_integration_create + t_realm->notifications_integration_create
+	permission notifications_daily_digest_preference_view = t_user_grant->notifications_daily_digest_preference_view + t_realm->notifications_daily_digest_preference_view
+}
+
+definition rbac/group {
+	permission owner = t_owner
+	relation t_owner: rbac/tenant
+	permission member = t_member
+	relation t_member: rbac/user | rbac/group#member
+}
+
+definition rbac/role {
+	permission notifications_integration_write = t_notifications_integration_write
+	relation t_notifications_integration_write: rbac/user:*
+	permission notifications_integration_view = notifications_integration_read
+	permission notifications_integration_view_history = notifications_integration_read
+	permission notifications_integration_read = t_notifications_integration_read
+	relation t_notifications_integration_read: rbac/user:*
+	permission notifications_daily_digest_preference_edit = notifications_integration_write
+	permission notifications_integration_test = notifications_integration_write
+	permission notifications_integration_delete = notifications_integration_write
+	permission notifications_integration_disable = notifications_integration_write
+	permission notifications_integration_enable = notifications_integration_write
+	permission notifications_daily_digest_preference_view = notifications_integration_read
+	permission notifications_event_log_view = notifications_integration_read
+	permission notifications_integration_edit = notifications_integration_write
+	permission notifications_integration_create = notifications_integration_read
+	permission notifications_integration_subscribe_drawer = notifications_integration_write
+	permission notifications_integration_subscribe_email = notifications_integration_write
+}
+
+definition rbac/role_binding {
+	permission notifications_integration_enable = (subject & t_granted->notifications_integration_enable)
+	permission notifications_event_log_view = (subject & t_granted->notifications_event_log_view)
+	permission notifications_integration_edit = (subject & t_granted->notifications_integration_edit)
+	permission subject = t_subject
+	relation t_subject: rbac/user | rbac/group#member
+	permission notifications_integration_view_history = (subject & t_granted->notifications_integration_view_history)
+	permission granted = t_granted
+	relation t_granted: rbac/role
+	permission notifications_daily_digest_preference_edit = (subject & t_granted->notifications_daily_digest_preference_edit)
+	permission notifications_integration_subscribe_email = (subject & t_granted->notifications_integration_subscribe_email)
+	permission notifications_integration_test = (subject & t_granted->notifications_integration_test)
+	permission notifications_integration_delete = (subject & t_granted->notifications_integration_delete)
+	permission notifications_integration_disable = (subject & t_granted->notifications_integration_disable)
+	permission notifications_integration_create = (subject & t_granted->notifications_integration_create)
+	permission notifications_daily_digest_preference_view = (subject & t_granted->notifications_daily_digest_preference_view)
+	permission notifications_integration_subscribe_drawer = (subject & t_granted->notifications_integration_subscribe_drawer)
+	permission notifications_integration_view = (subject & t_granted->notifications_integration_view)
+}
+
+definition rbac/workspace {
+	permission notifications_integration_enable = t_user_grant->notifications_integration_enable + t_parent->notifications_integration_enable
+	permission notifications_daily_digest_preference_view = t_user_grant->notifications_daily_digest_preference_view + t_parent->notifications_daily_digest_preference_view
+	permission notifications_integration_test = t_user_grant->notifications_integration_test + t_parent->notifications_integration_test
+	permission notifications_integration_edit = t_user_grant->notifications_integration_edit + t_parent->notifications_integration_edit
+	permission notifications_integration_create = t_user_grant->notifications_integration_create + t_parent->notifications_integration_create
+	permission notifications_daily_digest_preference_edit = t_user_grant->notifications_daily_digest_preference_edit + t_parent->notifications_daily_digest_preference_edit
+	permission notifications_integration_subscribe_drawer = t_user_grant->notifications_integration_subscribe_drawer + t_parent->notifications_integration_subscribe_drawer
+	permission notifications_integration_view = t_user_grant->notifications_integration_view + t_parent->notifications_integration_view
+	permission parent = t_parent
+	relation t_parent: rbac/workspace | rbac/tenant
+	permission user_grant = t_user_grant
+	relation t_user_grant: rbac/role_binding
+	permission notifications_integration_delete = t_user_grant->notifications_integration_delete + t_parent->notifications_integration_delete
+	permission notifications_integration_disable = t_user_grant->notifications_integration_disable + t_parent->notifications_integration_disable
+	permission notifications_integration_subscribe_email = t_user_grant->notifications_integration_subscribe_email + t_parent->notifications_integration_subscribe_email
+	permission notifications_event_log_view = t_user_grant->notifications_event_log_view + t_parent->notifications_event_log_view
+	permission notifications_integration_view_history = t_user_grant->notifications_integration_view_history + t_parent->notifications_integration_view_history
+}
+
+definition rbac/user {}

--- a/schema.zed
+++ b/schema.zed
@@ -1,3 +1,65 @@
+definition rbac/workspace {
+	permission parent = t_parent
+	relation t_parent: rbac/workspace | rbac/tenant
+	permission notifications_daily_digest_preference_view = t_user_grant->notifications_daily_digest_preference_view + t_parent->notifications_daily_digest_preference_view
+	permission notifications_integration_subscribe_drawer = t_user_grant->notifications_integration_subscribe_drawer + t_parent->notifications_integration_subscribe_drawer
+	permission notifications_event_log_view = t_user_grant->notifications_event_log_view + t_parent->notifications_event_log_view
+	permission notifications_integration_view = t_user_grant->notifications_integration_view + t_parent->notifications_integration_view
+	permission notifications_daily_digest_preference_edit = t_user_grant->notifications_daily_digest_preference_edit + t_parent->notifications_daily_digest_preference_edit
+	permission notifications_integration_subscribe_email = t_user_grant->notifications_integration_subscribe_email + t_parent->notifications_integration_subscribe_email
+	permission notifications_integration_delete = t_user_grant->notifications_integration_delete + t_parent->notifications_integration_delete
+	permission user_grant = t_user_grant
+	relation t_user_grant: rbac/role_binding
+	permission notifications_integration_create = t_user_grant->notifications_integration_create + t_parent->notifications_integration_create
+	permission notifications_integration_edit = t_user_grant->notifications_integration_edit + t_parent->notifications_integration_edit
+	permission notifications_integration_disable = t_user_grant->notifications_integration_disable + t_parent->notifications_integration_disable
+	permission notifications_integration_enable = t_user_grant->notifications_integration_enable + t_parent->notifications_integration_enable
+	permission notifications_integration_test = t_user_grant->notifications_integration_test + t_parent->notifications_integration_test
+	permission notifications_integration_view_history = t_user_grant->notifications_integration_view_history + t_parent->notifications_integration_view_history
+}
+
+definition rbac/user {}
+
+definition rbac/realm {
+	permission notifications_daily_digest_preference_edit = t_user_grant->notifications_daily_digest_preference_edit
+	permission notifications_event_log_view = t_user_grant->notifications_event_log_view
+	permission notifications_integration_disable = t_user_grant->notifications_integration_disable
+	permission notifications_integration_enable = t_user_grant->notifications_integration_enable
+	permission notifications_integration_subscribe_drawer = t_user_grant->notifications_integration_subscribe_drawer
+	permission notifications_integration_subscribe_email = t_user_grant->notifications_integration_subscribe_email
+	permission notifications_integration_test = t_user_grant->notifications_integration_test
+	permission notifications_integration_view_history = t_user_grant->notifications_integration_view_history
+	permission user_grant = t_user_grant
+	relation t_user_grant: rbac/role_binding
+	permission notifications_integration_create = t_user_grant->notifications_integration_create
+	permission notifications_integration_edit = t_user_grant->notifications_integration_edit
+	permission notifications_integration_delete = t_user_grant->notifications_integration_delete
+	permission notifications_daily_digest_preference_view = t_user_grant->notifications_daily_digest_preference_view
+	permission notifications_integration_view = t_user_grant->notifications_integration_view
+}
+
+definition rbac/tenant {
+	permission member = t_member
+	relation t_member: rbac/user
+	permission notifications_daily_digest_preference_edit = t_user_grant->notifications_daily_digest_preference_edit + t_realm->notifications_daily_digest_preference_edit
+	permission notifications_daily_digest_preference_view = t_user_grant->notifications_daily_digest_preference_view + t_realm->notifications_daily_digest_preference_view
+	permission notifications_integration_subscribe_drawer = t_user_grant->notifications_integration_subscribe_drawer + t_realm->notifications_integration_subscribe_drawer
+	permission notifications_integration_subscribe_email = t_user_grant->notifications_integration_subscribe_email + t_realm->notifications_integration_subscribe_email
+	permission notifications_integration_view = t_user_grant->notifications_integration_view + t_realm->notifications_integration_view
+	permission notifications_integration_edit = t_user_grant->notifications_integration_edit + t_realm->notifications_integration_edit
+	permission user_grant = t_user_grant
+	relation t_user_grant: rbac/role_binding
+	permission notifications_integration_disable = t_user_grant->notifications_integration_disable + t_realm->notifications_integration_disable
+	permission notifications_integration_delete = t_user_grant->notifications_integration_delete + t_realm->notifications_integration_delete
+	permission notifications_integration_enable = t_user_grant->notifications_integration_enable + t_realm->notifications_integration_enable
+	permission notifications_integration_create = t_user_grant->notifications_integration_create + t_realm->notifications_integration_create
+	permission notifications_event_log_view = t_user_grant->notifications_event_log_view + t_realm->notifications_event_log_view
+	permission notifications_integration_test = t_user_grant->notifications_integration_test + t_realm->notifications_integration_test
+	permission notifications_integration_view_history = t_user_grant->notifications_integration_view_history + t_realm->notifications_integration_view_history
+	permission realm = t_realm
+	relation t_realm: rbac/realm
+}
+
 definition rbac/group {
 	permission member = t_member
 	relation t_member: rbac/user | rbac/group#member
@@ -6,108 +68,47 @@ definition rbac/group {
 }
 
 definition rbac/role {
-	permission notifications_integration_delete = notifications_integration_write
-	permission notifications_integration_disable = notifications_integration_write
-	permission notifications_integration_view_history = notifications_integration_read
-	permission notifications_daily_digest_preference_view = notifications_integration_read
-	permission notifications_integration_view = notifications_integration_read
+	permission notifications_integration_subscribe_email = notifications_integration_write
 	permission notifications_event_log_view = notifications_integration_read
-	permission notifications_integration_edit = notifications_integration_write
+	permission notifications_integration_view = notifications_integration_read
 	permission notifications_integration_test = notifications_integration_write
-	permission notifications_integration_read = t_notifications_integration_read
-	relation t_notifications_integration_read: rbac/user:*
+	permission notifications_integration_delete = notifications_integration_write
 	permission notifications_integration_enable = notifications_integration_write
-	permission notifications_integration_create = notifications_integration_read
 	permission notifications_daily_digest_preference_edit = notifications_integration_write
-	permission notifications_integration_subscribe_drawer = notifications_integration_write
+	permission notifications_daily_digest_preference_view = notifications_integration_read
+	permission notifications_integration_edit = notifications_integration_write
+	permission notifications_integration_view_history = notifications_integration_read
+	permission notifications_integration_disable = notifications_integration_write
 	permission notifications_integration_write = t_notifications_integration_write
 	relation t_notifications_integration_write: rbac/user:*
-	permission notifications_integration_subscribe_email = notifications_integration_write
+	permission notifications_integration_subscribe_drawer = notifications_integration_write
+	permission notifications_integration_read = t_notifications_integration_read
+	relation t_notifications_integration_read: rbac/user:*
+	permission notifications_integration_create = notifications_integration_read
 }
 
 definition rbac/role_binding {
-	permission notifications_integration_disable = (subject & t_granted->notifications_integration_disable)
-	permission notifications_integration_create = (subject & t_granted->notifications_integration_create)
-	permission notifications_daily_digest_preference_view = (subject & t_granted->notifications_daily_digest_preference_view)
-	permission notifications_integration_subscribe_email = (subject & t_granted->notifications_integration_subscribe_email)
 	permission granted = t_granted
 	relation t_granted: rbac/role
-	permission notifications_integration_subscribe_drawer = (subject & t_granted->notifications_integration_subscribe_drawer)
+	permission notifications_integration_create = (subject & t_granted->notifications_integration_create)
+	permission notifications_integration_subscribe_email = (subject & t_granted->notifications_integration_subscribe_email)
 	permission notifications_integration_view = (subject & t_granted->notifications_integration_view)
-	permission notifications_integration_view_history = (subject & t_granted->notifications_integration_view_history)
-	permission notifications_daily_digest_preference_edit = (subject & t_granted->notifications_daily_digest_preference_edit)
+	permission notifications_integration_delete = (subject & t_granted->notifications_integration_delete)
+	permission notifications_integration_disable = (subject & t_granted->notifications_integration_disable)
+	permission notifications_event_log_view = (subject & t_granted->notifications_event_log_view)
 	permission subject = t_subject
 	relation t_subject: rbac/user | rbac/group#member
-	permission notifications_integration_delete = (subject & t_granted->notifications_integration_delete)
-	permission notifications_integration_enable = (subject & t_granted->notifications_integration_enable)
-	permission notifications_event_log_view = (subject & t_granted->notifications_event_log_view)
+	permission notifications_daily_digest_preference_view = (subject & t_granted->notifications_daily_digest_preference_view)
+	permission notifications_integration_subscribe_drawer = (subject & t_granted->notifications_integration_subscribe_drawer)
+	permission notifications_integration_view_history = (subject & t_granted->notifications_integration_view_history)
+	permission notifications_daily_digest_preference_edit = (subject & t_granted->notifications_daily_digest_preference_edit)
 	permission notifications_integration_edit = (subject & t_granted->notifications_integration_edit)
 	permission notifications_integration_test = (subject & t_granted->notifications_integration_test)
-}
-
-definition rbac/workspace {
-	permission notifications_daily_digest_preference_edit = t_user_grant->notifications_daily_digest_preference_edit + t_parent->notifications_daily_digest_preference_edit
-	permission notifications_integration_edit = t_user_grant->notifications_integration_edit + t_parent->notifications_integration_edit
-	permission parent = t_parent
-	relation t_parent: rbac/workspace | rbac/tenant
-	permission user_grant = t_user_grant
-	relation t_user_grant: rbac/role_binding
-	permission notifications_integration_disable = t_user_grant->notifications_integration_disable + t_parent->notifications_integration_disable
-	permission notifications_integration_create = t_user_grant->notifications_integration_create + t_parent->notifications_integration_create
-	permission notifications_daily_digest_preference_view = t_user_grant->notifications_daily_digest_preference_view + t_parent->notifications_daily_digest_preference_view
-	permission notifications_event_log_view = t_user_grant->notifications_event_log_view + t_parent->notifications_event_log_view
-	permission notifications_integration_view_history = t_user_grant->notifications_integration_view_history + t_parent->notifications_integration_view_history
-	permission notifications_integration_delete = t_user_grant->notifications_integration_delete + t_parent->notifications_integration_delete
-	permission notifications_integration_subscribe_drawer = t_user_grant->notifications_integration_subscribe_drawer + t_parent->notifications_integration_subscribe_drawer
-	permission notifications_integration_subscribe_email = t_user_grant->notifications_integration_subscribe_email + t_parent->notifications_integration_subscribe_email
-	permission notifications_integration_view = t_user_grant->notifications_integration_view + t_parent->notifications_integration_view
-	permission notifications_integration_test = t_user_grant->notifications_integration_test + t_parent->notifications_integration_test
-	permission notifications_integration_enable = t_user_grant->notifications_integration_enable + t_parent->notifications_integration_enable
-}
-
-definition rbac/user {}
-
-definition rbac/realm {
-	permission notifications_daily_digest_preference_view = t_user_grant->notifications_daily_digest_preference_view
-	permission notifications_integration_test = t_user_grant->notifications_integration_test
-	permission notifications_integration_view_history = t_user_grant->notifications_integration_view_history
-	permission notifications_integration_enable = t_user_grant->notifications_integration_enable
-	permission notifications_daily_digest_preference_edit = t_user_grant->notifications_daily_digest_preference_edit
-	permission notifications_integration_subscribe_drawer = t_user_grant->notifications_integration_subscribe_drawer
-	permission notifications_integration_edit = t_user_grant->notifications_integration_edit
-	permission user_grant = t_user_grant
-	relation t_user_grant: rbac/role_binding
-	permission notifications_integration_delete = t_user_grant->notifications_integration_delete
-	permission notifications_integration_subscribe_email = t_user_grant->notifications_integration_subscribe_email
-	permission notifications_event_log_view = t_user_grant->notifications_event_log_view
-	permission notifications_integration_view = t_user_grant->notifications_integration_view
-	permission notifications_integration_disable = t_user_grant->notifications_integration_disable
-	permission notifications_integration_create = t_user_grant->notifications_integration_create
-}
-
-definition rbac/tenant {
-	permission realm = t_realm
-	relation t_realm: rbac/realm
-	permission user_grant = t_user_grant
-	relation t_user_grant: rbac/role_binding
-	permission notifications_daily_digest_preference_edit = t_user_grant->notifications_daily_digest_preference_edit + t_realm->notifications_daily_digest_preference_edit
-	permission notifications_integration_delete = t_user_grant->notifications_integration_delete + t_realm->notifications_integration_delete
-	permission notifications_integration_enable = t_user_grant->notifications_integration_enable + t_realm->notifications_integration_enable
-	permission notifications_integration_subscribe_drawer = t_user_grant->notifications_integration_subscribe_drawer + t_realm->notifications_integration_subscribe_drawer
-	permission notifications_integration_test = t_user_grant->notifications_integration_test + t_realm->notifications_integration_test
-	permission notifications_integration_edit = t_user_grant->notifications_integration_edit + t_realm->notifications_integration_edit
-	permission notifications_integration_disable = t_user_grant->notifications_integration_disable + t_realm->notifications_integration_disable
-	permission notifications_integration_subscribe_email = t_user_grant->notifications_integration_subscribe_email + t_realm->notifications_integration_subscribe_email
-	permission notifications_event_log_view = t_user_grant->notifications_event_log_view + t_realm->notifications_event_log_view
-	permission notifications_integration_view = t_user_grant->notifications_integration_view + t_realm->notifications_integration_view
-	permission member = t_member
-	relation t_member: rbac/user
-	permission notifications_integration_view_history = t_user_grant->notifications_integration_view_history + t_realm->notifications_integration_view_history
-	permission notifications_integration_create = t_user_grant->notifications_integration_create + t_realm->notifications_integration_create
-	permission notifications_daily_digest_preference_view = t_user_grant->notifications_daily_digest_preference_view + t_realm->notifications_daily_digest_preference_view
+	permission notifications_integration_enable = (subject & t_granted->notifications_integration_enable)
 }
 
 definition notifications/integration {
+	permission view = t_workspace->notifications_integration_view
 	permission edit = t_workspace->notifications_integration_edit
 	permission test = t_workspace->notifications_integration_test
 	permission view_history = t_workspace->notifications_integration_view_history
@@ -116,5 +117,4 @@ definition notifications/integration {
 	permission enable = t_workspace->notifications_integration_enable
 	permission workspace = t_workspace
 	relation t_workspace: rbac/workspace
-	permission view = t_workspace->notifications_integration_view
 }

--- a/schema.zed
+++ b/schema.zed
@@ -1,120 +1,111 @@
-definition rbac/realm {
-	permission notifications_integration_view_history = t_user_grant->notifications_integration_view_history
-	permission notifications_integration_enable = t_user_grant->notifications_integration_enable
-	permission notifications_integration_subscribe_drawer = t_user_grant->notifications_integration_subscribe_drawer
-	permission notifications_integration_subscribe_email = t_user_grant->notifications_integration_subscribe_email
+definition rbac/group {
+	permission member = t_member
+	relation t_member: rbac/user | rbac/group#member
+	permission owner = t_owner
+	relation t_owner: rbac/tenant
+}
+
+definition rbac/role {
+	permission notifications_integration_delete = notifications_integration_write
+	permission notifications_integration_disable = notifications_integration_write
+	permission notifications_integration_view_history = notifications_integration_read
+	permission notifications_daily_digest_preference_view = notifications_integration_read
+	permission notifications_integration_view = notifications_integration_read
+	permission notifications_event_log_view = notifications_integration_read
+	permission notifications_integration_edit = notifications_integration_write
+	permission notifications_integration_test = notifications_integration_write
+	permission notifications_integration_read = t_notifications_integration_read
+	relation t_notifications_integration_read: rbac/user:*
+	permission notifications_integration_enable = notifications_integration_write
+	permission notifications_integration_create = notifications_integration_read
+	permission notifications_daily_digest_preference_edit = notifications_integration_write
+	permission notifications_integration_subscribe_drawer = notifications_integration_write
+	permission notifications_integration_write = t_notifications_integration_write
+	relation t_notifications_integration_write: rbac/user:*
+	permission notifications_integration_subscribe_email = notifications_integration_write
+}
+
+definition rbac/role_binding {
+	permission notifications_integration_disable = (subject & t_granted->notifications_integration_disable)
+	permission notifications_integration_create = (subject & t_granted->notifications_integration_create)
+	permission notifications_daily_digest_preference_view = (subject & t_granted->notifications_daily_digest_preference_view)
+	permission notifications_integration_subscribe_email = (subject & t_granted->notifications_integration_subscribe_email)
+	permission granted = t_granted
+	relation t_granted: rbac/role
+	permission notifications_integration_subscribe_drawer = (subject & t_granted->notifications_integration_subscribe_drawer)
+	permission notifications_integration_view = (subject & t_granted->notifications_integration_view)
+	permission notifications_integration_view_history = (subject & t_granted->notifications_integration_view_history)
+	permission notifications_daily_digest_preference_edit = (subject & t_granted->notifications_daily_digest_preference_edit)
+	permission subject = t_subject
+	relation t_subject: rbac/user | rbac/group#member
+	permission notifications_integration_delete = (subject & t_granted->notifications_integration_delete)
+	permission notifications_integration_enable = (subject & t_granted->notifications_integration_enable)
+	permission notifications_event_log_view = (subject & t_granted->notifications_event_log_view)
+	permission notifications_integration_edit = (subject & t_granted->notifications_integration_edit)
+	permission notifications_integration_test = (subject & t_granted->notifications_integration_test)
+}
+
+definition rbac/workspace {
+	permission notifications_daily_digest_preference_edit = t_user_grant->notifications_daily_digest_preference_edit + t_parent->notifications_daily_digest_preference_edit
+	permission notifications_integration_edit = t_user_grant->notifications_integration_edit + t_parent->notifications_integration_edit
+	permission parent = t_parent
+	relation t_parent: rbac/workspace | rbac/tenant
 	permission user_grant = t_user_grant
 	relation t_user_grant: rbac/role_binding
-	permission notifications_daily_digest_preference_edit = t_user_grant->notifications_daily_digest_preference_edit
+	permission notifications_integration_disable = t_user_grant->notifications_integration_disable + t_parent->notifications_integration_disable
+	permission notifications_integration_create = t_user_grant->notifications_integration_create + t_parent->notifications_integration_create
+	permission notifications_daily_digest_preference_view = t_user_grant->notifications_daily_digest_preference_view + t_parent->notifications_daily_digest_preference_view
+	permission notifications_event_log_view = t_user_grant->notifications_event_log_view + t_parent->notifications_event_log_view
+	permission notifications_integration_view_history = t_user_grant->notifications_integration_view_history + t_parent->notifications_integration_view_history
+	permission notifications_integration_delete = t_user_grant->notifications_integration_delete + t_parent->notifications_integration_delete
+	permission notifications_integration_subscribe_drawer = t_user_grant->notifications_integration_subscribe_drawer + t_parent->notifications_integration_subscribe_drawer
+	permission notifications_integration_subscribe_email = t_user_grant->notifications_integration_subscribe_email + t_parent->notifications_integration_subscribe_email
+	permission notifications_integration_view = t_user_grant->notifications_integration_view + t_parent->notifications_integration_view
+	permission notifications_integration_test = t_user_grant->notifications_integration_test + t_parent->notifications_integration_test
+	permission notifications_integration_enable = t_user_grant->notifications_integration_enable + t_parent->notifications_integration_enable
+}
+
+definition rbac/user {}
+
+definition rbac/realm {
 	permission notifications_daily_digest_preference_view = t_user_grant->notifications_daily_digest_preference_view
-	permission notifications_event_log_view = t_user_grant->notifications_event_log_view
-	permission notifications_integration_edit = t_user_grant->notifications_integration_edit
 	permission notifications_integration_test = t_user_grant->notifications_integration_test
+	permission notifications_integration_view_history = t_user_grant->notifications_integration_view_history
+	permission notifications_integration_enable = t_user_grant->notifications_integration_enable
+	permission notifications_daily_digest_preference_edit = t_user_grant->notifications_daily_digest_preference_edit
+	permission notifications_integration_subscribe_drawer = t_user_grant->notifications_integration_subscribe_drawer
+	permission notifications_integration_edit = t_user_grant->notifications_integration_edit
+	permission user_grant = t_user_grant
+	relation t_user_grant: rbac/role_binding
 	permission notifications_integration_delete = t_user_grant->notifications_integration_delete
-	permission notifications_integration_disable = t_user_grant->notifications_integration_disable
+	permission notifications_integration_subscribe_email = t_user_grant->notifications_integration_subscribe_email
+	permission notifications_event_log_view = t_user_grant->notifications_event_log_view
 	permission notifications_integration_view = t_user_grant->notifications_integration_view
+	permission notifications_integration_disable = t_user_grant->notifications_integration_disable
 	permission notifications_integration_create = t_user_grant->notifications_integration_create
 }
 
 definition rbac/tenant {
 	permission realm = t_realm
 	relation t_realm: rbac/realm
-	permission notifications_integration_test = t_user_grant->notifications_integration_test + t_realm->notifications_integration_test
-	permission notifications_event_log_view = t_user_grant->notifications_event_log_view + t_realm->notifications_event_log_view
-	permission notifications_integration_subscribe_drawer = t_user_grant->notifications_integration_subscribe_drawer + t_realm->notifications_integration_subscribe_drawer
 	permission user_grant = t_user_grant
 	relation t_user_grant: rbac/role_binding
-	permission notifications_integration_edit = t_user_grant->notifications_integration_edit + t_realm->notifications_integration_edit
-	permission notifications_integration_view_history = t_user_grant->notifications_integration_view_history + t_realm->notifications_integration_view_history
-	permission notifications_integration_delete = t_user_grant->notifications_integration_delete + t_realm->notifications_integration_delete
 	permission notifications_daily_digest_preference_edit = t_user_grant->notifications_daily_digest_preference_edit + t_realm->notifications_daily_digest_preference_edit
+	permission notifications_integration_delete = t_user_grant->notifications_integration_delete + t_realm->notifications_integration_delete
+	permission notifications_integration_enable = t_user_grant->notifications_integration_enable + t_realm->notifications_integration_enable
+	permission notifications_integration_subscribe_drawer = t_user_grant->notifications_integration_subscribe_drawer + t_realm->notifications_integration_subscribe_drawer
+	permission notifications_integration_test = t_user_grant->notifications_integration_test + t_realm->notifications_integration_test
+	permission notifications_integration_edit = t_user_grant->notifications_integration_edit + t_realm->notifications_integration_edit
+	permission notifications_integration_disable = t_user_grant->notifications_integration_disable + t_realm->notifications_integration_disable
+	permission notifications_integration_subscribe_email = t_user_grant->notifications_integration_subscribe_email + t_realm->notifications_integration_subscribe_email
+	permission notifications_event_log_view = t_user_grant->notifications_event_log_view + t_realm->notifications_event_log_view
+	permission notifications_integration_view = t_user_grant->notifications_integration_view + t_realm->notifications_integration_view
 	permission member = t_member
 	relation t_member: rbac/user
-	permission notifications_integration_subscribe_email = t_user_grant->notifications_integration_subscribe_email + t_realm->notifications_integration_subscribe_email
-	permission notifications_integration_disable = t_user_grant->notifications_integration_disable + t_realm->notifications_integration_disable
-	permission notifications_integration_enable = t_user_grant->notifications_integration_enable + t_realm->notifications_integration_enable
+	permission notifications_integration_view_history = t_user_grant->notifications_integration_view_history + t_realm->notifications_integration_view_history
 	permission notifications_integration_create = t_user_grant->notifications_integration_create + t_realm->notifications_integration_create
 	permission notifications_daily_digest_preference_view = t_user_grant->notifications_daily_digest_preference_view + t_realm->notifications_daily_digest_preference_view
-	permission notifications_integration_view = t_user_grant->notifications_integration_view + t_realm->notifications_integration_view
 }
-
-definition rbac/group {
-	permission owner = t_owner
-	relation t_owner: rbac/tenant
-	permission member = t_member
-	relation t_member: rbac/user | rbac/group#member
-}
-
-definition rbac/role {
-	permission notifications_event_log_view = t_notifications_event_log_view
-	relation t_notifications_event_log_view: rbac/user:*
-	permission notifications_integration_view = t_notifications_integration_view
-	relation t_notifications_integration_view: rbac/user:*
-	permission notifications_integration_edit = t_notifications_integration_edit
-	relation t_notifications_integration_edit: rbac/user:*
-	permission notifications_integration_view_history = t_notifications_integration_view_history
-	relation t_notifications_integration_view_history: rbac/user:*
-	permission notifications_integration_delete = t_notifications_integration_delete
-	relation t_notifications_integration_delete: rbac/user:*
-	permission notifications_integration_disable = t_notifications_integration_disable
-	relation t_notifications_integration_disable: rbac/user:*
-	permission notifications_integration_enable = t_notifications_integration_enable
-	relation t_notifications_integration_enable: rbac/user:*
-	permission notifications_integration_create = t_notifications_integration_create
-	relation t_notifications_integration_create: rbac/user:*
-	permission notifications_integration_test = t_notifications_integration_test
-	relation t_notifications_integration_test: rbac/user:*
-	permission notifications_daily_digest_preference_edit = t_notifications_daily_digest_preference_edit
-	relation t_notifications_daily_digest_preference_edit: rbac/user:*
-	permission notifications_daily_digest_preference_view = t_notifications_daily_digest_preference_view
-	relation t_notifications_daily_digest_preference_view: rbac/user:*
-	permission notifications_integration_subscribe_drawer = t_notifications_integration_subscribe_drawer
-	relation t_notifications_integration_subscribe_drawer: rbac/user:*
-	permission notifications_integration_subscribe_email = t_notifications_integration_subscribe_email
-	relation t_notifications_integration_subscribe_email: rbac/user:*
-}
-
-definition rbac/role_binding {
-	permission notifications_event_log_view = (subject & t_granted->notifications_event_log_view)
-	permission notifications_integration_view = (subject & t_granted->notifications_integration_view)
-	permission subject = t_subject
-	relation t_subject: rbac/user | rbac/group#member
-	permission notifications_integration_disable = (subject & t_granted->notifications_integration_disable)
-	permission notifications_integration_subscribe_email = (subject & t_granted->notifications_integration_subscribe_email)
-	permission notifications_integration_subscribe_drawer = (subject & t_granted->notifications_integration_subscribe_drawer)
-	permission notifications_integration_test = (subject & t_granted->notifications_integration_test)
-	permission notifications_integration_view_history = (subject & t_granted->notifications_integration_view_history)
-	permission notifications_integration_delete = (subject & t_granted->notifications_integration_delete)
-	permission notifications_integration_enable = (subject & t_granted->notifications_integration_enable)
-	permission notifications_daily_digest_preference_edit = (subject & t_granted->notifications_daily_digest_preference_edit)
-	permission notifications_daily_digest_preference_view = (subject & t_granted->notifications_daily_digest_preference_view)
-	permission granted = t_granted
-	relation t_granted: rbac/role
-	permission notifications_integration_edit = (subject & t_granted->notifications_integration_edit)
-	permission notifications_integration_create = (subject & t_granted->notifications_integration_create)
-}
-
-definition rbac/workspace {
-	permission notifications_integration_delete = t_user_grant->notifications_integration_delete + t_parent->notifications_integration_delete
-	permission notifications_integration_enable = t_user_grant->notifications_integration_enable + t_parent->notifications_integration_enable
-	permission notifications_integration_test = t_user_grant->notifications_integration_test + t_parent->notifications_integration_test
-	permission notifications_integration_view_history = t_user_grant->notifications_integration_view_history + t_parent->notifications_integration_view_history
-	permission notifications_integration_edit = t_user_grant->notifications_integration_edit + t_parent->notifications_integration_edit
-	permission notifications_daily_digest_preference_view = t_user_grant->notifications_daily_digest_preference_view + t_parent->notifications_daily_digest_preference_view
-	permission notifications_integration_subscribe_email = t_user_grant->notifications_integration_subscribe_email + t_parent->notifications_integration_subscribe_email
-	permission notifications_integration_view = t_user_grant->notifications_integration_view + t_parent->notifications_integration_view
-	permission notifications_daily_digest_preference_edit = t_user_grant->notifications_daily_digest_preference_edit + t_parent->notifications_daily_digest_preference_edit
-	permission user_grant = t_user_grant
-	relation t_user_grant: rbac/role_binding
-	permission notifications_integration_disable = t_user_grant->notifications_integration_disable + t_parent->notifications_integration_disable
-	permission notifications_integration_create = t_user_grant->notifications_integration_create + t_parent->notifications_integration_create
-	permission notifications_integration_subscribe_drawer = t_user_grant->notifications_integration_subscribe_drawer + t_parent->notifications_integration_subscribe_drawer
-	permission notifications_event_log_view = t_user_grant->notifications_event_log_view + t_parent->notifications_event_log_view
-	permission parent = t_parent
-	relation t_parent: rbac/workspace | rbac/tenant
-}
-
-definition rbac/user {}
 
 definition notifications/integration {
 	permission edit = t_workspace->notifications_integration_edit

--- a/schema.zed
+++ b/schema.zed
@@ -1,86 +1,129 @@
-// TODO: should we prefix all relations?
-// TODO: do we need to distinguish between service account and user principles as separate types?
-definition rbac/user {}
-
-// TODO: Add permissions here
 definition rbac/realm {
-	relation user_grant: rbac/role_binding
+	permission notifications_integration_view_history = t_user_grant->notifications_integration_view_history
+	permission notifications_integration_enable = t_user_grant->notifications_integration_enable
+	permission notifications_integration_subscribe_drawer = t_user_grant->notifications_integration_subscribe_drawer
+	permission notifications_integration_subscribe_email = t_user_grant->notifications_integration_subscribe_email
+	permission user_grant = t_user_grant
+	relation t_user_grant: rbac/role_binding
+	permission notifications_daily_digest_preference_edit = t_user_grant->notifications_daily_digest_preference_edit
+	permission notifications_daily_digest_preference_view = t_user_grant->notifications_daily_digest_preference_view
+	permission notifications_event_log_view = t_user_grant->notifications_event_log_view
+	permission notifications_integration_edit = t_user_grant->notifications_integration_edit
+	permission notifications_integration_test = t_user_grant->notifications_integration_test
+	permission notifications_integration_delete = t_user_grant->notifications_integration_delete
+	permission notifications_integration_disable = t_user_grant->notifications_integration_disable
+	permission notifications_integration_view = t_user_grant->notifications_integration_view
+	permission notifications_integration_create = t_user_grant->notifications_integration_create
 }
 
-// TODO: Add permissions here OR roll up to realm directly from top level workspaces instead of tenant.
 definition rbac/tenant {
-	// Every tenant should be connected to a common "realm" for global bindings.
-	relation realm: rbac/realm
-	relation user_grant: rbac/role_binding
-	relation member: rbac/user
+	permission realm = t_realm
+	relation t_realm: rbac/realm
+	permission notifications_integration_test = t_user_grant->notifications_integration_test + t_realm->notifications_integration_test
+	permission notifications_event_log_view = t_user_grant->notifications_event_log_view + t_realm->notifications_event_log_view
+	permission notifications_integration_subscribe_drawer = t_user_grant->notifications_integration_subscribe_drawer + t_realm->notifications_integration_subscribe_drawer
+	permission user_grant = t_user_grant
+	relation t_user_grant: rbac/role_binding
+	permission notifications_integration_edit = t_user_grant->notifications_integration_edit + t_realm->notifications_integration_edit
+	permission notifications_integration_view_history = t_user_grant->notifications_integration_view_history + t_realm->notifications_integration_view_history
+	permission notifications_integration_delete = t_user_grant->notifications_integration_delete + t_realm->notifications_integration_delete
+	permission notifications_daily_digest_preference_edit = t_user_grant->notifications_daily_digest_preference_edit + t_realm->notifications_daily_digest_preference_edit
+	permission member = t_member
+	relation t_member: rbac/user
+	permission notifications_integration_subscribe_email = t_user_grant->notifications_integration_subscribe_email + t_realm->notifications_integration_subscribe_email
+	permission notifications_integration_disable = t_user_grant->notifications_integration_disable + t_realm->notifications_integration_disable
+	permission notifications_integration_enable = t_user_grant->notifications_integration_enable + t_realm->notifications_integration_enable
+	permission notifications_integration_create = t_user_grant->notifications_integration_create + t_realm->notifications_integration_create
+	permission notifications_daily_digest_preference_view = t_user_grant->notifications_daily_digest_preference_view + t_realm->notifications_daily_digest_preference_view
+	permission notifications_integration_view = t_user_grant->notifications_integration_view + t_realm->notifications_integration_view
 }
 
 definition rbac/group {
-	relation owner: rbac/tenant
-	relation member: rbac/user | rbac/group#member
+	permission owner = t_owner
+	relation t_owner: rbac/tenant
+	permission member = t_member
+	relation t_member: rbac/user | rbac/group#member
 }
 
 definition rbac/role {
-	relation notifications_daily_digest_preference_edit: rbac/user:*
-	relation notifications_daily_digest_preference_view: rbac/user:*
-	relation notifications_integration_create: rbac/user:*
-	relation notifications_integration_subscribe_drawer: rbac/user:*
-	relation notifications_integration_subscribe_email: rbac/user:*
-	relation notifications_integration_view: rbac/user:*
-	relation notifications_integration_edit: rbac/user:*
-	relation notifications_integration_test: rbac/user:*
-	relation notifications_integration_view_history: rbac/user:*
-	relation notifications_integration_delete: rbac/user:*
-	relation notifications_integration_disable: rbac/user:*
-	relation notifications_integration_enable: rbac/user:*
-	relation notifications_event_log_view: rbac/user:*
+	permission notifications_event_log_view = t_notifications_event_log_view
+	relation t_notifications_event_log_view: rbac/user:*
+	permission notifications_integration_view = t_notifications_integration_view
+	relation t_notifications_integration_view: rbac/user:*
+	permission notifications_integration_edit = t_notifications_integration_edit
+	relation t_notifications_integration_edit: rbac/user:*
+	permission notifications_integration_view_history = t_notifications_integration_view_history
+	relation t_notifications_integration_view_history: rbac/user:*
+	permission notifications_integration_delete = t_notifications_integration_delete
+	relation t_notifications_integration_delete: rbac/user:*
+	permission notifications_integration_disable = t_notifications_integration_disable
+	relation t_notifications_integration_disable: rbac/user:*
+	permission notifications_integration_enable = t_notifications_integration_enable
+	relation t_notifications_integration_enable: rbac/user:*
+	permission notifications_integration_create = t_notifications_integration_create
+	relation t_notifications_integration_create: rbac/user:*
+	permission notifications_integration_test = t_notifications_integration_test
+	relation t_notifications_integration_test: rbac/user:*
+	permission notifications_daily_digest_preference_edit = t_notifications_daily_digest_preference_edit
+	relation t_notifications_daily_digest_preference_edit: rbac/user:*
+	permission notifications_daily_digest_preference_view = t_notifications_daily_digest_preference_view
+	relation t_notifications_daily_digest_preference_view: rbac/user:*
+	permission notifications_integration_subscribe_drawer = t_notifications_integration_subscribe_drawer
+	relation t_notifications_integration_subscribe_drawer: rbac/user:*
+	permission notifications_integration_subscribe_email = t_notifications_integration_subscribe_email
+	relation t_notifications_integration_subscribe_email: rbac/user:*
 }
 
 definition rbac/role_binding {
-	relation subject: rbac/user | rbac/group#member
-	relation granted: rbac/role
-	permission notifications_daily_digest_preference_edit = subject & granted->notifications_daily_digest_preference_edit
-	permission notifications_daily_digest_preference_view = subject & granted->notifications_daily_digest_preference_view
-	permission notifications_integration_create = subject & granted->notifications_integration_create
-	permission notifications_integration_subscribe_drawer = subject & granted->notifications_integration_subscribe_drawer
-	permission notifications_integration_subscribe_email = subject & granted->notifications_integration_subscribe_email
-	permission notifications_integration_view = subject & granted->notifications_integration_view
-	permission notifications_integration_edit = subject & granted->notifications_integration_edit
-	permission notifications_integration_test = subject & granted->notifications_integration_test
-	permission notifications_integration_view_history = subject & granted->notifications_integration_view_history
-	permission notifications_integration_delete = subject & granted->notifications_integration_delete
-	permission notifications_integration_disable = subject & granted->notifications_integration_disable
-	permission notifications_integration_enable = subject & granted->notifications_integration_enable
-	permission notifications_event_log_view = subject & granted->notifications_event_log_view
+	permission notifications_event_log_view = (subject & t_granted->notifications_event_log_view)
+	permission notifications_integration_view = (subject & t_granted->notifications_integration_view)
+	permission subject = t_subject
+	relation t_subject: rbac/user | rbac/group#member
+	permission notifications_integration_disable = (subject & t_granted->notifications_integration_disable)
+	permission notifications_integration_subscribe_email = (subject & t_granted->notifications_integration_subscribe_email)
+	permission notifications_integration_subscribe_drawer = (subject & t_granted->notifications_integration_subscribe_drawer)
+	permission notifications_integration_test = (subject & t_granted->notifications_integration_test)
+	permission notifications_integration_view_history = (subject & t_granted->notifications_integration_view_history)
+	permission notifications_integration_delete = (subject & t_granted->notifications_integration_delete)
+	permission notifications_integration_enable = (subject & t_granted->notifications_integration_enable)
+	permission notifications_daily_digest_preference_edit = (subject & t_granted->notifications_daily_digest_preference_edit)
+	permission notifications_daily_digest_preference_view = (subject & t_granted->notifications_daily_digest_preference_view)
+	permission granted = t_granted
+	relation t_granted: rbac/role
+	permission notifications_integration_edit = (subject & t_granted->notifications_integration_edit)
+	permission notifications_integration_create = (subject & t_granted->notifications_integration_create)
 }
 
 definition rbac/workspace {
-	relation parent: rbac/workspace | rbac/tenant
-	relation user_grant: rbac/role_binding
-	permission notifications_daily_digest_preference_edit = user_grant->notifications_daily_digest_preference_edit + parent->notifications_daily_digest_preference_edit
-	permission notifications_daily_digest_preference_view = user_grant->notifications_daily_digest_preference_view + parent->notifications_daily_digest_preference_view
-	permission notifications_integration_create = user_grant->notifications_integration_create + parent->notifications_integration_create
-	permission notifications_integration_subscribe_drawer = user_grant->notifications_integration_subscribe_drawer + parent->notifications_integration_subscribe_drawer
-	permission notifications_integration_subscribe_email = user_grant->notifications_integration_subscribe_email + parent->notifications_integration_subscribe_email
-	permission notifications_integration_view = user_grant->notifications_integration_view + parent->notifications_integration_view
-	permission notifications_integration_edit = user_grant->notifications_integration_edit + parent->notifications_integration_edit
-	permission notifications_integration_test = user_grant->notifications_integration_test + parent->notifications_integration_test
-	permission notifications_integration_view_history = user_grant->notifications_integration_view_history + parent->notifications_integration_view_history
-	permission notifications_integration_delete = user_grant->notifications_integration_delete + parent->notifications_integration_delete
-	permission notifications_integration_disable = user_grant->notifications_integration_disable + parent->notifications_integration_disable
-	permission notifications_integration_enable = user_grant->notifications_integration_enable + parent->notifications_integration_enable
-	permission notifications_event_log_view = user_grant->notifications_event_log_view + parent->notifications_event_log_view
+	permission notifications_integration_delete = t_user_grant->notifications_integration_delete + t_parent->notifications_integration_delete
+	permission notifications_integration_enable = t_user_grant->notifications_integration_enable + t_parent->notifications_integration_enable
+	permission notifications_integration_test = t_user_grant->notifications_integration_test + t_parent->notifications_integration_test
+	permission notifications_integration_view_history = t_user_grant->notifications_integration_view_history + t_parent->notifications_integration_view_history
+	permission notifications_integration_edit = t_user_grant->notifications_integration_edit + t_parent->notifications_integration_edit
+	permission notifications_daily_digest_preference_view = t_user_grant->notifications_daily_digest_preference_view + t_parent->notifications_daily_digest_preference_view
+	permission notifications_integration_subscribe_email = t_user_grant->notifications_integration_subscribe_email + t_parent->notifications_integration_subscribe_email
+	permission notifications_integration_view = t_user_grant->notifications_integration_view + t_parent->notifications_integration_view
+	permission notifications_daily_digest_preference_edit = t_user_grant->notifications_daily_digest_preference_edit + t_parent->notifications_daily_digest_preference_edit
+	permission user_grant = t_user_grant
+	relation t_user_grant: rbac/role_binding
+	permission notifications_integration_disable = t_user_grant->notifications_integration_disable + t_parent->notifications_integration_disable
+	permission notifications_integration_create = t_user_grant->notifications_integration_create + t_parent->notifications_integration_create
+	permission notifications_integration_subscribe_drawer = t_user_grant->notifications_integration_subscribe_drawer + t_parent->notifications_integration_subscribe_drawer
+	permission notifications_event_log_view = t_user_grant->notifications_event_log_view + t_parent->notifications_event_log_view
+	permission parent = t_parent
+	relation t_parent: rbac/workspace | rbac/tenant
 }
 
-definition notifications/integration {
-	relation workspace: rbac/workspace
-	permission view = workspace->notifications_integration_view
+definition rbac/user {}
 
-	// Edit display name, connectivity settings, and event type mappings
-	permission edit = workspace->notifications_integration_edit
-	permission test = workspace->notifications_integration_test
-	permission view_history = workspace->notifications_integration_view_history
-	permission delete = workspace->notifications_integration_delete
-	permission disable = workspace->notifications_integration_disable
-	permission enable = workspace->notifications_integration_enable
+definition notifications/integration {
+	permission edit = t_workspace->notifications_integration_edit
+	permission test = t_workspace->notifications_integration_test
+	permission view_history = t_workspace->notifications_integration_view_history
+	permission delete = t_workspace->notifications_integration_delete
+	permission disable = t_workspace->notifications_integration_disable
+	permission enable = t_workspace->notifications_integration_enable
+	permission workspace = t_workspace
+	relation t_workspace: rbac/workspace
+	permission view = t_workspace->notifications_integration_view
 }

--- a/src/notifications.ksl
+++ b/src/notifications.ksl
@@ -4,33 +4,33 @@ module notifications
 import rbac
 
 type integration {
-    @rbac.add_permission(workspace_perm:'notifications_integration_create')
-    @rbac.add_permission(workspace_perm:'notifications_daily_digest_preference_edit')
-    @rbac.add_permission(workspace_perm:'notifications_daily_digest_preference_view')
-    @rbac.add_permission(workspace_perm:'notifications_integration_subscribe_drawer')
-    @rbac.add_permission(workspace_perm:'notifications_integration_subscribe_email')
-    @rbac.add_permission(workspace_perm:'notifications_event_log_view')
+    @rbac.add_v1_based_permission(v1_perm:'notifications_integration_read', v2_perm:'notifications_integration_create')
+    @rbac.add_v1_based_permission(v1_perm:'notifications_integration_write', v2_perm:'notifications_daily_digest_preference_edit')
+    @rbac.add_v1_based_permission(v1_perm:'notifications_integration_read', v2_perm:'notifications_daily_digest_preference_view')
+    @rbac.add_v1_based_permission(v1_perm:'notifications_integration_write', v2_perm:'notifications_integration_subscribe_drawer')
+    @rbac.add_v1_based_permission(v1_perm:'notifications_integration_write', v2_perm:'notifications_integration_subscribe_email')
+    @rbac.add_v1_based_permission(v1_perm:'notifications_integration_read', v2_perm:'notifications_event_log_view')
     relation workspace: [ExactlyOne rbac.workspace]
 
-    @rbac.add_permission(workspace_perm:'notifications_integration_view')
+    @rbac.add_v1_based_permission(v1_perm:'notifications_integration_read', v2_perm:'notifications_integration_view')
     relation view: workspace.notifications_integration_view
 
     // Edit display name, connectivity settings, and event type mappings
-    @rbac.add_permission(workspace_perm:'notifications_integration_edit')
+    @rbac.add_v1_based_permission(v1_perm:'notifications_integration_write', v2_perm:'notifications_integration_edit')
     relation edit: workspace.notifications_integration_edit
 
-    @rbac.add_permission(workspace_perm:'notifications_integration_test')
+    @rbac.add_v1_based_permission(v1_perm:'notifications_integration_write', v2_perm:'notifications_integration_test')
     relation test: workspace.notifications_integration_test
 
-    @rbac.add_permission(workspace_perm:'notifications_integration_view_history')
+    @rbac.add_v1_based_permission(v1_perm:'notifications_integration_read', v2_perm:'notifications_integration_view_history')
     relation view_history: workspace.notifications_integration_view_history
 
-    @rbac.add_permission(workspace_perm:'notifications_integration_delete')
+    @rbac.add_v1_based_permission(v1_perm:'notifications_integration_write', v2_perm:'notifications_integration_delete')
     relation delete: workspace.notifications_integration_delete
 
-    @rbac.add_permission(workspace_perm:'notifications_integration_disable')
+    @rbac.add_v1_based_permission(v1_perm:'notifications_integration_write', v2_perm:'notifications_integration_disable')
     relation disable: workspace.notifications_integration_disable
 
-    @rbac.add_permission(workspace_perm:'notifications_integration_enable')
+    @rbac.add_v1_based_permission(v1_perm:'notifications_integration_write', v2_perm:'notifications_integration_enable')
     relation enable: workspace.notifications_integration_enable
 }

--- a/src/notifications.ksl
+++ b/src/notifications.ksl
@@ -1,5 +1,5 @@
 version 0.1
-module notifications
+namespace notifications
 
 import rbac
 

--- a/src/notifications.ksl
+++ b/src/notifications.ksl
@@ -1,0 +1,36 @@
+version 0.1
+module notifications
+
+import rbac
+
+type integration {
+    @rbac.add_permission(workspace_perm:'notifications_integration_create')
+    @rbac.add_permission(workspace_perm:'notifications_daily_digest_preference_edit')
+    @rbac.add_permission(workspace_perm:'notifications_daily_digest_preference_view')
+    @rbac.add_permission(workspace_perm:'notifications_integration_subscribe_drawer')
+    @rbac.add_permission(workspace_perm:'notifications_integration_subscribe_email')
+    @rbac.add_permission(workspace_perm:'notifications_event_log_view')
+    relation workspace: [ExactlyOne rbac.workspace]
+
+    @rbac.add_permission(workspace_perm:'notifications_integration_view')
+    relation view: workspace.notifications_integration_view
+
+    // Edit display name, connectivity settings, and event type mappings
+    @rbac.add_permission(workspace_perm:'notifications_integration_edit')
+    relation edit: workspace.notifications_integration_edit
+
+    @rbac.add_permission(workspace_perm:'notifications_integration_test')
+    relation test: workspace.notifications_integration_test
+
+    @rbac.add_permission(workspace_perm:'notifications_integration_view_history')
+    relation view_history: workspace.notifications_integration_view_history
+
+    @rbac.add_permission(workspace_perm:'notifications_integration_delete')
+    relation delete: workspace.notifications_integration_delete
+
+    @rbac.add_permission(workspace_perm:'notifications_integration_disable')
+    relation disable: workspace.notifications_integration_disable
+
+    @rbac.add_permission(workspace_perm:'notifications_integration_enable')
+    relation enable: workspace.notifications_integration_enable
+}

--- a/src/rbac.ksl
+++ b/src/rbac.ksl
@@ -1,7 +1,7 @@
 version 0.1
-module rbac
+namespace rbac
 
-// TODO: do we need to distinguish between service
+// TODO: do we need to distinguish between service account and user principles as separate types?
 type user {}
 
 type realm {
@@ -21,7 +21,7 @@ type group {
 
 type role {}
 
-type role_binding { // Revisit cardinality based on clamping decisions
+type role_binding { // TODO: revisit cardinality based on clamping decisions
     relation subject: [Any user or group.member]
     relation granted: [Any role]
 }
@@ -31,30 +31,7 @@ public type workspace {
     relation user_grant: [Any role_binding]
 }
 
-
-public extension add_v1_compatible_permission(v1_perm, v2_perm) {
-    type role {
-        allow_duplicates relation `${v1_perm}`: [bool]
-        relation `${v2_perm}`: [bool] or `${v1_perm}`
-    }
-
-    type role_binding {
-        relation `${v2_perm}`: subject and granted.`${v2_perm}`
-    }
-
-    type realm {
-        relation `${v2_perm}`: user_grant.`${v2_perm}`
-    }
-
-    type tenant {
-        relation `${v2_perm}`: user_grant.`${v2_perm}` or realm.`${v2_perm}`
-    }
-
-    type workspace {
-        relation `${v2_perm}`: user_grant.`${v2_perm}` or parent.`${v2_perm}`
-    }
-}
-
+// Adds a permission that's checkable at the workspace but granted by assigning a different, V1 permission to the role
 public extension add_v1_based_permission(v1_perm, v2_perm) {
     type role {
         allow_duplicates relation `${v1_perm}`: [bool]
@@ -78,6 +55,7 @@ public extension add_v1_based_permission(v1_perm, v2_perm) {
     }
 }
 
+// Adds a permission that's both assignable to a role and checkable at a workspace
 public extension add_permission(workspace_perm) {
     type role {
         relation `${workspace_perm}`: [bool]

--- a/src/rbac.ksl
+++ b/src/rbac.ksl
@@ -1,0 +1,77 @@
+version 0.1
+module rbac
+
+type user {}
+
+type realm {
+    relation user_grant: [Any role_binding]
+}
+
+type tenant {
+    relation realm: [ExactlyOne realm]
+    relation user_grant: [Any role_binding]
+    relation member: [Any user]
+}
+
+type group {
+    relation owner: [ExactlyOne tenant]
+    relation member: [Any user or group.member]
+}
+
+type role {}
+
+type role_binding { // Revisit cardinality based on clamping decisions
+    relation subject: [Any user or group.member]
+    relation granted: [Any role]
+}
+
+public type workspace {
+    relation parent: [ExactlyOne workspace or tenant]
+    relation user_grant: [Any role_binding]
+}
+
+
+public extension add_permission_with_legacy(legacy_perm, granular_perm) {
+    type role {
+        allow_duplicates relation `${legacy_perm}`: [bool]
+        relation `${granular_perm}`: [bool]
+    }
+
+    type role_binding {
+        relation `${granular_perm}`: subject and (granted.`${granular_perm}` or granted.`${legacy_perm}`)
+    }
+
+    type realm {
+        relation `${granular_perm}`: user_grant.`${granular_perm}`
+    }
+
+    type tenant {
+        relation `${granular_perm}`: user_grant.`${granular_perm}` or realm.`${granular_perm}`
+    }
+
+    type workspace {
+        relation `${granular_perm}`: user_grant.`${granular_perm}` or parent.`${granular_perm}`
+    }
+}
+
+public extension add_permission(workspace_perm) {
+    type role {
+        relation `${workspace_perm}`: [bool]
+    }
+
+    type role_binding {
+        relation `${workspace_perm}`: subject and granted.`${workspace_perm}`
+    }
+
+    type realm {
+        relation `${workspace_perm}`: user_grant.`${workspace_perm}`
+    }
+
+    type tenant {
+        relation `${workspace_perm}`: user_grant.`${workspace_perm}` or realm.`${workspace_perm}`
+    }
+
+    type workspace {
+        relation `${workspace_perm}`: user_grant.`${workspace_perm}` or parent.`${workspace_perm}`
+    }
+}

--- a/src/rbac.ksl
+++ b/src/rbac.ksl
@@ -1,6 +1,7 @@
 version 0.1
 module rbac
 
+// TODO: do we need to distinguish between service
 type user {}
 
 type realm {

--- a/src/rbac.ksl
+++ b/src/rbac.ksl
@@ -35,11 +35,34 @@ public type workspace {
 public extension add_v1_compatible_permission(v1_perm, v2_perm) {
     type role {
         allow_duplicates relation `${v1_perm}`: [bool]
-        relation `${v2_perm}`: [bool]
+        relation `${v2_perm}`: [bool] or `${v1_perm}`
     }
 
     type role_binding {
-        relation `${v2_perm}`: subject and (granted.`${v2_perm}` or granted.`${v1_perm}`)
+        relation `${v2_perm}`: subject and granted.`${v2_perm}`
+    }
+
+    type realm {
+        relation `${v2_perm}`: user_grant.`${v2_perm}`
+    }
+
+    type tenant {
+        relation `${v2_perm}`: user_grant.`${v2_perm}` or realm.`${v2_perm}`
+    }
+
+    type workspace {
+        relation `${v2_perm}`: user_grant.`${v2_perm}` or parent.`${v2_perm}`
+    }
+}
+
+public extension add_v1_based_permission(v1_perm, v2_perm) {
+    type role {
+        allow_duplicates relation `${v1_perm}`: [bool]
+        relation `${v2_perm}`: `${v1_perm}`
+    }
+
+    type role_binding {
+        relation `${v2_perm}`: subject and granted.`${v2_perm}`
     }
 
     type realm {

--- a/src/rbac.ksl
+++ b/src/rbac.ksl
@@ -2,31 +2,32 @@ version 0.1
 namespace rbac
 
 // TODO: do we need to distinguish between service account and user principles as separate types?
-type user {}
+public type user {} //public for now since the [bool] type requires rbac/user to be accessible
 
-type realm {
+// Other types for structuring access are marked internal but can be made public if services are intended to relate to them
+internal type realm {
     relation user_grant: [Any role_binding]
 }
 
-type tenant {
+internal type tenant {
     relation realm: [ExactlyOne realm]
     relation user_grant: [Any role_binding]
     relation member: [Any user]
 }
 
-type group {
+internal type group {
     relation owner: [ExactlyOne tenant]
     relation member: [Any user or group.member]
 }
 
-type role {}
+internal type role {}
 
-type role_binding { // TODO: revisit cardinality based on clamping decisions
+internal type role_binding { // TODO: revisit cardinality based on clamping decisions
     relation subject: [Any user or group.member]
     relation granted: [Any role]
 }
 
-public type workspace {
+public type workspace { //Workspace is public so services can place resources into workspaces
     relation parent: [ExactlyOne workspace or tenant]
     relation user_grant: [Any role_binding]
 }
@@ -34,7 +35,7 @@ public type workspace {
 // Adds a permission that's checkable at the workspace but granted by assigning a different, V1 permission to the role
 public extension add_v1_based_permission(v1_perm, v2_perm) {
     type role {
-        allow_duplicates relation `${v1_perm}`: [bool]
+        allow_duplicates private relation `${v1_perm}`: [bool] //v1 relations are private so they can only be used within the role type (for the corresponding v2 permissions)
         relation `${v2_perm}`: `${v1_perm}`
     }
 

--- a/src/rbac.ksl
+++ b/src/rbac.ksl
@@ -32,26 +32,26 @@ public type workspace {
 }
 
 
-public extension add_permission_with_legacy(legacy_perm, granular_perm) {
+public extension add_v1_compatible_permission(v1_perm, v2_perm) {
     type role {
-        allow_duplicates relation `${legacy_perm}`: [bool]
-        relation `${granular_perm}`: [bool]
+        allow_duplicates relation `${v1_perm}`: [bool]
+        relation `${v2_perm}`: [bool]
     }
 
     type role_binding {
-        relation `${granular_perm}`: subject and (granted.`${granular_perm}` or granted.`${legacy_perm}`)
+        relation `${v2_perm}`: subject and (granted.`${v2_perm}` or granted.`${v1_perm}`)
     }
 
     type realm {
-        relation `${granular_perm}`: user_grant.`${granular_perm}`
+        relation `${v2_perm}`: user_grant.`${v2_perm}`
     }
 
     type tenant {
-        relation `${granular_perm}`: user_grant.`${granular_perm}` or realm.`${granular_perm}`
+        relation `${v2_perm}`: user_grant.`${v2_perm}` or realm.`${v2_perm}`
     }
 
     type workspace {
-        relation `${granular_perm}`: user_grant.`${granular_perm}` or parent.`${granular_perm}`
+        relation `${v2_perm}`: user_grant.`${v2_perm}` or parent.`${v2_perm}`
     }
 }
 


### PR DESCRIPTION
- Templates out the current schema in experimental KSL Schema Language
- Implements schema prefixing as required by https://issues.redhat.com/browse/RHCLOUD-34867
- ..And consequently requires it
- Resolves schema warnings